### PR TITLE
prevent the items from covering the main menu

### DIFF
--- a/socobo-list-item.html
+++ b/socobo-list-item.html
@@ -4,20 +4,20 @@
 <link rel="import" href="../paper-checkbox/paper-checkbox.html">
 <link rel="import" href="../paper-item/paper-item.html">
 <link rel="import" href="../paper-material/paper-material.html">
-
-<!-- Todo: Add your Polymer Element Imports here: -->
-
+<link rel="import" href="../iron-flex-layout/classes/iron-flex-layout.html">
 
 <dom-module id="socobo-list-item">
   <style>
     :host{
     }
     .short_info {
-      position: relative;
+      @apply(--layout-horizontal);
+      @apply(--layout-center);
       height: 50px;
       line-height: 50px;
       border-bottom: solid 2px #F4F0EC;
       color: #8A7F80;
+      padding-right: 16px;
     }
 
     .short_info:hover{
@@ -25,162 +25,32 @@
     }
 
     .check {
-      position: absolute;
-      width: 110px;
-      height: 50px;
-      text-align: center;
+      margin-left: 32px; 
     }
 
     .desc, .info {
-      z-index: 5;
       font-family: sans-serif;
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;
-      position: absolute;
     }
 
     .desc {
-      left: 110px;
-      padding-right: 160px;
-      margin-right: 160px;
+      @apply(--layout-flex);
+      margin-left: var(--socobo-list-item-desc-margin-left, 32px);
     }
 
     .info{
-      position: absolute;
-      right : 450px;
-    }
-
-    .delete{
-      position: absolute;
-      right: 0;
-      z-index: 10;
-      width: 110px;
-      height: 50px;
-      text-align: center;
+      @apply(--layout-flex);
     }
 
     .edit{
-      z-index: 10;
-      position: absolute;
-      right: 110px;
-      width: 50px;
-      height: 50px;
-      text-align: center;
+      margin-right: 16px
     }
 
     iron-icon:hover{
       color: var(--default-primary-color);
     }
-
-    @media all and (min-width:300px) and (max-width : 450px) {
-      .desc{
-        width: 90px;
-        left: 60px;
-      }
-
-      .info{
-        right : 100px;
-      }
-
-      .delete{
-        width: 60px;
-      }
-
-      .edit{
-        right: 60px;
-        width: 30px
-      }
-
-      .check{
-        width: 60px;
-      }
-    }
-
-    @media all and (min-width:451px) and (max-width : 600px) {
-      .desc{
-        width: 150px;
-      }
-
-      .info{
-        right : 150px;
-      }
-
-      .delete{
-        width: 60px;
-      }
-
-      .edit{
-        right: 60px;
-        width: 30px
-      }
-
-      .check{
-        width: 60px;
-      }
-    }
-
-    @media all and (min-width:601px) and (max-width : 750px) {
-      .desc{
-        width: 250px;
-      }
-
-      .info{
-        right : 200px;
-      }
-
-
-    }
-
-    @media all and (min-width:751px) and (max-width : 900px) {
-      .desc{
-        width: 320px;
-      }
-
-      .info{
-        right : 230px;
-      }
-    }
-
-    @media all and (min-width:901px) and (max-width : 1080px) {
-      .desc{
-        width: 420px;
-      }
-
-      .info{
-        right : 300px;
-      }
-    }
-
-    @media all and (min-width:1081px) and (max-width : 1280px) {
-      .desc{
-        width: 530px;
-      }
-
-      .info{
-        right : 350px;
-      }
-    }
-
-    @media all and (min-width:1281px) and (max-width : 1500px) {
-      .desc{
-        width: 680px;
-      }
-
-      .info{
-        right : 400px;
-      }
-    }
-    @media all and (min-width:1501px) and (max-width : 1800px){
-      .desc{
-        width: 850px;
-      }
-
-      .info{
-        right : 450px;
-      }
-    }
-
   </style>
 
   <template>

--- a/test/index.html
+++ b/test/index.html
@@ -9,7 +9,7 @@
 <body>
   <script>
     WCT.loadSuites([
-      'socobo-element-template.html'
+      'socobo-list-item.html'
     ]);
   </script>
 </body>

--- a/test/socobo-list-item.html
+++ b/test/socobo-list-item.html
@@ -10,7 +10,7 @@
   <script src="../bower_components/test-fixture/test-fixture-mocha.js"></script>
   <script src="../bower_components/iron-test-helpers/mock-interactions.js"></script>
 
-  <link rel="import" href="../socobo-recipe-overview.html">
+  <link rel="import" href="../socobo-list-item.html">
   <link rel="import" href="../bower_components/test-fixture/test-fixture.html">
 </head>
 <body>


### PR DESCRIPTION
Use iron-flex-layout to arrange elements in the list item and remove z-index to prevent the items from covering the main menu